### PR TITLE
Seed board tasks and update docs

### DIFF
--- a/board_mvp/README.md
+++ b/board_mvp/README.md
@@ -27,3 +27,9 @@ uvicorn board_mvp.web:app --reload
 
 This serves the API under `/api` and a very small HTML interface at `/` for listing
 and creating quests.
+
+### Seeding Initial Project Quests
+
+Run `python -m board_mvp.seed_tasks` to populate the board with a couple of
+starter users and quests drawn from `mvp_board_plan.md`. This is the first step
+toward tracking CivicForge development directly within the Board.

--- a/board_mvp/seed_tasks.py
+++ b/board_mvp/seed_tasks.py
@@ -1,0 +1,51 @@
+import os
+from board_mvp import api
+
+"""Seed the board database with initial users and quests for project tracking."""
+
+
+def ensure_user(username: str, real_name: str, role: str) -> api.models.User:
+    """Create a user if it doesn't already exist."""
+    cur = api.conn.cursor()
+    cur.execute("SELECT id FROM users WHERE username=?", (username,))
+    row = cur.fetchone()
+    if row:
+        return api.get_user_by_id(row[0])
+    return api.create_user(api.UserCreate(username=username, real_name=real_name, role=role))
+
+
+def ensure_quest(title: str, creator_id: int, description: str) -> api.models.Quest:
+    """Create a quest if a matching one does not already exist."""
+    cur = api.conn.cursor()
+    cur.execute("SELECT id FROM quests WHERE title=? AND creator_id=?", (title, creator_id))
+    row = cur.fetchone()
+    if row:
+        return api.get_quest_by_id(row[0])
+    return api.create_quest(api.QuestCreate(title=title, description=description, reward=0, creator_id=creator_id))
+
+
+def main():
+    db_path = os.environ.get("BOARD_DB_PATH", api.DB_PATH)
+    print(f"Seeding tasks using database at {db_path}")
+
+    # Create initial users representing the core team
+    admin = ensure_user("admin", "CivicForge Admin", "Organizer")
+    dev = ensure_user("dev", "Core Developer", "Participant")
+
+    # Outstanding tasks from mvp_board_plan.md
+    ensure_quest(
+        "Migrate project tracking to the Board",
+        admin.id,
+        "Start using the MVP board for tracking development tasks and feedback.",
+    )
+    ensure_quest(
+        "Implement Forge API stubs",
+        admin.id,
+        "Add placeholder endpoints for identity verification and board/feature registration.",
+    )
+
+    print("Seeding complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mvp_board_plan.md
+++ b/mvp_board_plan.md
@@ -70,8 +70,9 @@ The current codebase does not yet provide these stubs. Planned tasks include:
      handling.
 7. **(done)** Write integration tests for the quest lifecycle.
    * Tests now cover the web UI routes as well.
-8. Move development tracking and CivicForge feedback onto the first Board once the basic web UI is usable.
-   * Next agent: begin migrating project tracking to the Board.
+8. **(in progress)** Move development tracking and CivicForge feedback onto the first Board once the basic web UI is usable.
+   * A helper script `board_mvp/seed_tasks.py` seeds the Board with initial quests for upcoming work.
+   * Next agent: continue adding tasks through the web UI and reference them in pull request descriptions.
 9. Document and implement the Forge API stubs described above.
 
 ### Potential Issues

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,14 @@ Most importantly, imagine seeing **your neighbors becoming more engaged, more co
 
 CivicForge is designed to be an **adaptive system**—one that learns and improves based on real community feedback and measurable impact. The platform includes robust analytics (StatsBoard) to track not just activity, but actual positive community outcomes.
 
+### Tracking Development on the MVP Board
+
+The repository now includes a helper script to seed the MVP Board with initial
+project-tracking quests. Run `python -m board_mvp.seed_tasks` to create sample
+users and quests from `mvp_board_plan.md`. After running the script, open the
+web interface (see `board_mvp/README.md`) to manage development work directly on
+the Board.
+
 **This isn't just about building better software—it's about building better communities.** Communities where good intentions become organized action, where individual effort contributes to collective impact, and where digital tools serve human flourishing.
 
 ---


### PR DESCRIPTION
## Summary
- add `seed_tasks.py` for initializing quests on the MVP board
- document seed script usage in board README
- document board tracking workflow in main README
- mark step 8 as in progress in `mvp_board_plan.md`

## Testing
- `python -m board_mvp.seed_tasks`
- `python board_mvp/run_tests.py`