### PR TITLE
Fix ECS health check failures causing task instability

### DIFF
--- a/deploy/aws/ecs-task-definition.json.template
+++ b/deploy/aws/ecs-task-definition.json.template
@@ -41,7 +41,7 @@
         }
       },
       "healthCheck": {
-        "command": ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"],
+        "command": ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health').read()\" || exit 1"],
         "interval": 30,
         "timeout": 5,
         "retries": 3,


### PR DESCRIPTION
## Summary
- Fixed ECS tasks failing health checks and causing frequent IP rotations
- Updated health check to use Python instead of curl (which wasn't installed)
- Corrected endpoint path from `/health` to `/api/health`

## Problem
The ECS service was experiencing continuous task failures with tasks being terminated due to failed health checks. This caused:
- Tasks restarting every ~2 minutes
- Frequent IP address changes
- Service instability

## Root Cause
1. The health check was using `curl` which wasn't installed in the container
2. The endpoint path was incorrect - should be `/api/health` since web.py mounts the API under `/api`

## Solution
Updated the ECS task definition template to use Python's urllib for health checks, pointing to the correct `/api/health` endpoint.

## Test Results
After applying this fix to the running service:
- Task health status: HEALTHY ✅
- Service stable with no restarts
- Application accessible at public IP

🤖 Generated with [Claude Code](https://claude.ai/code)